### PR TITLE
Bump gulp shell to drop gulp-util.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "gulp": "^3.9.0",
-    "gulp-shell": "^0.4.2"
+    "gulp-shell": "^0.6.4"
   },
   "scripts": {
     "pretest": "jshint index.js test.js",


### PR DESCRIPTION
Node 10 will not install any projects that dependn on gulp-graph as it has a dependency on an old verison of gulp-shell. This PR updates this.